### PR TITLE
Add TYPO3 v13 compatibility (also tested with TYPO3 v12)

### DIFF
--- a/Classes/Backend/EventListener/loginEventListener.php
+++ b/Classes/Backend/EventListener/loginEventListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cabag\CabagLoginas\Backend\EventListener;
+
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListHeaderColumnsEvent;
+use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent;
+use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListTableActionsEvent;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Cabag\CabagLoginas\Hook\ToolbarItemHook;
+
+
+final class loginEventListener
+{
+    private LoggerInterface $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+    /**
+     * @var $loginAsObj ToolbarItemHook
+     */
+    public $loginAsObj = NULL;
+
+    public function getLoginAsObject()
+    {
+        if ($this->loginAsObj === null) {
+            $this->loginAsObj = GeneralUtility::makeInstance(ToolbarItemHook::class);
+        }
+        return $this->loginAsObj;
+    }
+    public function modifyRecordActions(ModifyRecordListRecordActionsEvent $event): void
+    {
+
+        $table=$event->getTable();
+        if ($table === 'fe_users') {
+            $row=$event->getRecord();
+            // view is not used for fe_users, therefore we use it here
+            $newAction= $this->getLoginAsObject()->getLoginAsIconInTable($row);
+            $event->setAction($newAction);
+        }
+
+    }
+
+}

--- a/Classes/Hook/PostUserLookupHook.php
+++ b/Classes/Hook/PostUserLookupHook.php
@@ -46,14 +46,13 @@ class PostUserLookupHook {
         if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
             && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()
         ) {
-            if (!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-                if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
-                    $cabagLoginasData = GeneralUtility::_GP('Cabag\CabagLoginas\Hook\ToolbarItemHook');
-                }else{
+             $request = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
+             $frontendUser=$request->getAttribute('frontend.user');
+             
+            if (isset($frontendUser) && !empty($frontendUser->user['uid'])) {
                     $request = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
                     $cabagLoginasData = $request->getParsedBody()['Cabag\CabagLoginas\Hook\ToolbarItemHook'] ?? $request->getQueryParams()['Cabag\CabagLoginas\Hook\ToolbarItemHook'] ?? null;
-                }
-                
+               
                 if (!empty($cabagLoginasData['redirecturl'])) {
                     $partsArray = parse_url(rawurldecode($cabagLoginasData['redirecturl']));
                     if (strpos(GeneralUtility::getIndpEnv('TYPO3_SITE_URL'), $partsArray['scheme'] . '://' . $partsArray['host'] . '/') === false) {

--- a/Classes/Hook/ToolbarItemHook.php
+++ b/Classes/Hook/ToolbarItemHook.php
@@ -124,7 +124,9 @@ class ToolbarItemHook implements ToolbarItemInterface
         $parameterArray['userid'] = (string)$user['uid'];
         $parameterArray['timeout'] = (string)$timeout = time() + 3600;
         // Check user settings for any redirect page
-        if ($user['felogin_redirectPid']) {
+
+        //update 12
+        if (@$user['felogin_redirectPid']) {
             $parameterArray['redirecturl'] = $this->getRedirectUrl($user['felogin_redirectPid']);
         } else {
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
@@ -173,7 +175,9 @@ class ToolbarItemHook implements ToolbarItemInterface
         if (trim($title) === '') {
             $title = $GLOBALS['LANG']->getLL('cabag_loginas.switchToFeuser', true);
         }
-        if (version_compare(TYPO3_version, '7.6.0', '>=')) {
+        //update 12
+        $typo3Version=GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+        if (version_compare(strval($typo3Version->getMajorVersion()), '7.6.0', '>=')) {
             $iconFactory = GeneralUtility::makeInstance('TYPO3\CMS\Core\Imaging\IconFactory');
             $switchUserIcon = $iconFactory->getIcon('actions-system-backend-user-switch', Icon::SIZE_SMALL)->render();
             $additionalClass = '  class="btn btn-default"';

--- a/Classes/Hook/ToolbarItemHook.php
+++ b/Classes/Hook/ToolbarItemHook.php
@@ -15,7 +15,7 @@ namespace Cabag\CabagLoginas\Hook;
  * The TYPO3 project - inspiring people to share!
  */
 
-use PDO;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Backend\Controller\BackendController;
 use TYPO3\CMS\Backend\Toolbar\ToolbarItemInterface;
 use TYPO3\CMS\Backend\Utility\IconUtility;
@@ -29,6 +29,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+
 
 class ToolbarItemHook implements ToolbarItemInterface
 {
@@ -57,7 +58,7 @@ class ToolbarItemHook implements ToolbarItemInterface
 
         $toolbarMenu = array();
 
-        $title = $GLOBALS['LANG']->getLL('fe_users.tx_cabagloginas_loginas', true);
+        $title = $GLOBALS['LANG']->sL('LLL:EXT:cabag_loginas/Resources/Private/Language/locallang_db.xlf:fe_users.tx_cabagloginas_loginas');
         $ext_conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cabag_loginas']);
         $defLinkText = trim($ext_conf['defLinkText']);
         if (empty($defLinkText) || strpos($defLinkText, '#') === false || strpos($defLinkText, 'password') !== false) {
@@ -70,10 +71,10 @@ class ToolbarItemHook implements ToolbarItemInterface
             ->getQueryBuilderForTable('fe_users');
         $this->users = $queryBuilder->select('*')
             ->from('fe_users')
-            ->where($queryBuilder->expr()->eq('email', $queryBuilder->createNamedParameter($email, PDO::PARAM_STR)))
+            ->where($queryBuilder->expr()->eq('email', $queryBuilder->createNamedParameter($email, Connection::PARAM_STR)))
             ->setMaxResults(15)
-            ->execute()
-            ->fetchAll();
+            ->executeQuery()
+            ->fetchAllAssociative();
 
         if (count($this->users)) {
             if (count($this->users) == 1) {
@@ -143,7 +144,7 @@ class ToolbarItemHook implements ToolbarItemInterface
                 ->where(
                     'fg.felogin_redirectPid != \'\'',
                     'fu.uid = ' . $user['uid']
-                )->execute()
+                )->executeQuery()
                 ->fetchAssociative();
 
             $parameterArray['redirecturl'] = $this->getRedirectUrl($userGroup['felogin_redirectPid'] ?? $user['pid']);
@@ -173,7 +174,7 @@ class ToolbarItemHook implements ToolbarItemInterface
     {
         $additionalClass = '';
         if (trim($title) === '') {
-            $title = $GLOBALS['LANG']->getLL('cabag_loginas.switchToFeuser', true);
+            $title = $GLOBALS['LANG']->sL('LLL:EXT:cabag_loginas/Resources/Private/Language/locallang_db.xlf:cabag_loginas.switchToFeuser');
         }
         //update 12
         $typo3Version=GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
@@ -218,11 +219,11 @@ class ToolbarItemHook implements ToolbarItemInterface
                 ->select('domainName', 'tx_cabagfileexplorer_redirect_to')
                 ->from('sys_domain')
                 ->where(
-                    $queryBuilder->expr()->eq('domainName', $queryBuilder->createNamedParameter($domainArray['host'], PDO::PARAM_STR))
+                    $queryBuilder->expr()->eq('domainName', $queryBuilder->createNamedParameter($domainArray['host'], Connection::PARAM_STR))
                 )
                 ->setMaxResults(1)
-                ->execute()
-                ->fetch();
+                ->executeQuery()
+                ->fetchAssociative();
         } else {
             $rowArray = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
                 'domainName, tx_cabagfileexplorer_redirect_to', 'sys_domain', 'hidden = 0 AND domainName = ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($domainArray['host'], 'sys_domain'), '', '', 1

--- a/Classes/Service/LoginAsService.php
+++ b/Classes/Service/LoginAsService.php
@@ -29,7 +29,13 @@ class LoginAsService extends AbstractAuthenticationService
     public function getUser()
     {
         $row = false;
-        $cabagLoginasData = GeneralUtility::_GP('tx_cabagloginas');
+        //update 12
+        if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
+            $cabagLoginasData = GeneralUtility::_GP('tx_cabagloginas');
+        }else{
+            $request = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
+            $cabagLoginasData = $request->getParsedBody()['tx_cabagloginas'] ?? $request->getQueryParams()['tx_cabagloginas'] ?? null;
+        }   
 
         if (isset($cabagLoginasData['verification'])) {
             $ses_id = $_COOKIE['be_typo_user'];

--- a/Classes/Service/LoginAsService.php
+++ b/Classes/Service/LoginAsService.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
-
+ use TYPO3\CMS\Core\Database\Connection;
 /**
  * This file is part of the TYPO3 CMS project.
  *
@@ -29,13 +29,9 @@ class LoginAsService extends AbstractAuthenticationService
     public function getUser()
     {
         $row = false;
-        //update 12
-        if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
-            $cabagLoginasData = GeneralUtility::_GP('tx_cabagloginas');
-        }else{
+
             $request = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
             $cabagLoginasData = $request->getParsedBody()['tx_cabagloginas'] ?? $request->getQueryParams()['tx_cabagloginas'] ?? null;
-        }   
 
         if (isset($cabagLoginasData['verification'])) {
             $ses_id = $_COOKIE['be_typo_user'];
@@ -56,13 +52,15 @@ class LoginAsService extends AbstractAuthenticationService
                         ->where(
                             $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($cabagLoginasData['userid'], \PDO::PARAM_INT))
                         )
-                        ->execute()
-                        ->fetchAll();
+                        ->executeQuery()
+                        ->fetchAllAssociative();
                 if ($user[0]) {
                     $row = $user[0];
                     $this->rowdata = $user[0];
-                    if (is_object($GLOBALS['TSFE']->fe_user)) {
-                        $GLOBALS['TSFE']->fe_user->setKey('ses', 'tx_cabagloginas', true);
+                    $frontendUser=$request->getAttribute('frontend.user');
+                    if (is_object($frontendUser)) {
+                            $frontendUser->setKey('ses', 'tx_cabagloginas', true);
+                            $frontendUser->storeSessionData();
                     }
                 }
             }

--- a/Classes/Xclass/FrontendUserAuthenticatorXclass.php
+++ b/Classes/Xclass/FrontendUserAuthenticatorXclass.php
@@ -32,8 +32,14 @@ class FrontendUserAuthenticatorXclass extends FrontendUserAuthenticator
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $FE_alwaysFetchUser = $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['FE_alwaysFetchUser'];
-        $cabag_loginas_data = GeneralUtility::_GP('tx_cabagloginas');
+        // update 12
+        $FE_alwaysFetchUser = @$GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['FE_alwaysFetchUser'];
+        if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
+            $cabag_loginas_data = GeneralUtility::_GP('tx_cabagloginas');
+        }else{
+            $requestcabagloginas = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
+            $cabag_loginas_data = $requestcabagloginas->getParsedBody()['tx_cabagloginas'] ?? $requestcabagloginas->getQueryParams()['tx_cabagloginas'] ?? null;
+        }
         if (isset($cabag_loginas_data['userid']) && ($cabag_loginas_data['userid'] > 0)) {
             // Trigger authentication without setting FE_alwaysFetchUser globally
             $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['FE_alwaysFetchUser'] = true;

--- a/Classes/Xclass/FrontendUserAuthenticatorXclass.php
+++ b/Classes/Xclass/FrontendUserAuthenticatorXclass.php
@@ -34,12 +34,8 @@ class FrontendUserAuthenticatorXclass extends FrontendUserAuthenticator
     {
         // update 12
         $FE_alwaysFetchUser = @$GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['FE_alwaysFetchUser'];
-        if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
-            $cabag_loginas_data = GeneralUtility::_GP('tx_cabagloginas');
-        }else{
-            $requestcabagloginas = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
-            $cabag_loginas_data = $requestcabagloginas->getParsedBody()['tx_cabagloginas'] ?? $requestcabagloginas->getQueryParams()['tx_cabagloginas'] ?? null;
-        }
+        $requestcabagloginas = &$GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
+        $cabag_loginas_data = $requestcabagloginas->getParsedBody()['tx_cabagloginas'] ?? $requestcabagloginas->getQueryParams()['tx_cabagloginas'] ?? null;
         if (isset($cabag_loginas_data['userid']) && ($cabag_loginas_data['userid'] > 0)) {
             // Trigger authentication without setting FE_alwaysFetchUser globally
             $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['FE_alwaysFetchUser'] = true;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,14 @@
+# Configuration/Services.yaml
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+  # Place here the default dependency injection configuration
+
+  Cabag\CabagLoginas\Backend\EventListener\loginEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'cabag/recordlist/login-event-listener'
+        method: 'modifyRecordActions'
+        event: TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
         die ('Access denied.');
 }
 $tempColumns = array(

--- a/Configuration/TCA/Overrides/sys_domain.php
+++ b/Configuration/TCA/Overrides/sys_domain.php
@@ -1,6 +1,8 @@
 <?php
 
-$tx_cabagloginas_extconf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cabag_loginas']);
+if(@$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cabag_loginas']){
+	$tx_cabagloginas_extconf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cabag_loginas']);
+}
 
 // if enabled, add the fields to the sys_domain
 if (!empty($tx_cabagloginas_extconf['enableDomainBasedRedirect'])) {

--- a/Resources/PHP/Toolbar.php
+++ b/Resources/PHP/Toolbar.php
@@ -1,10 +1,12 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
 	die ('Access denied.');
 }
 
-if (TYPO3_MODE == 'BE') {
+use TYPO3\CMS\Core\Http\ApplicationType;
+
+if (ApplicationType::fromRequest(@$GLOBALS['TYPO3_REQUEST'])->isBackend()) {
 	// register the class as toolbar item
 	$GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']['cabag_loginas'] = \Cabag\CabagLoginas\Hook\ToolbarItemHook::class;
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = array(
     'title' => 'CAB Login As',
     'description' => 'Within the backend you have a button in the fe_user table and in the upper right corner to quickly login as this fe user in frontend.',
     'category' => 'be',
-    'version' => '5.0.0',
+    'version' => '5.0.0 dev',
     'state' => 'stable',
     'uploadfolder' => true,
     'createDirs' => '',
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array(
         array(
             'depends' =>
                 array(
-                    'typo3' => '11.5.10-',
+                    'typo3' => '11.5.10-12.5.99',
                 ),
             'conflicts' =>
                 array(),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = array(
     'title' => 'CAB Login As',
     'description' => 'Within the backend you have a button in the fe_user table and in the upper right corner to quickly login as this fe user in frontend.',
     'category' => 'be',
-    'version' => '5.0.0 dev',
+    'version' => '7.0.0 dev',
     'state' => 'stable',
     'uploadfolder' => true,
     'createDirs' => '',
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array(
         array(
             'depends' =>
                 array(
-                    'typo3' => '11.5.10-12.5.99',
+                    'typo3' => '12.0.0-13.5.99',
                 ),
             'conflicts' =>
                 array(),

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,7 +2,7 @@
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
 	die ('Access denied.');
 }
 
@@ -18,7 +18,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Frontend\Middleware\Fron
 ];
 
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService($_EXTKEY, 'auth', 'Cabag\\CabagLoginas\\Service\\LoginAsService' /* sv key */,
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService('cabag_loginas', 'auth', 'Cabag\\CabagLoginas\\Service\\LoginAsService' /* sv key */,
 	array(
 
 		'title' => 'Login as Service',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,7 +7,9 @@ if (!defined('TYPO3')) {
 }
 
 // Hook for adding switch icon to website users
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'][] = 'Cabag\CabagLoginas\Hook\RecordListHook';
+if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
+	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'][] = 'Cabag\CabagLoginas\Hook\RecordListHook';
+}
 
 // Hook to check for redirection
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postUserLookUp'][] = 'Cabag\CabagLoginas\Hook\PostUserLookupHook->postUserLookUp';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,10 +6,6 @@ if (!defined('TYPO3')) {
 	die ('Access denied.');
 }
 
-// Hook for adding switch icon to website users
-if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
-	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'][] = 'Cabag\CabagLoginas\Hook\RecordListHook';
-}
 
 // Hook to check for redirection
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postUserLookUp'][] = 'Cabag\CabagLoginas\Hook\PostUserLookupHook->postUserLookUp';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
 	die ('Access denied.');
 }
 


### PR DESCRIPTION
This pull request adds compatibility for TYPO3 v13.



Changes include:

removal of deprecated TYPO3 APIs (e.g. TYPO3_MODE, GeneralUtility::_GP)

adjustments for newer TYPO3 versions

compatibility improvements for both TYPO3 v12 and v13



The extension has been tested with:

TYPO3 v12

TYPO3 v13



Both versions are working correctly.